### PR TITLE
Added role for app and fixed audiohooks default values

### DIFF
--- a/wizard/config/config.js
+++ b/wizard/config/config.js
@@ -77,13 +77,21 @@ export default {
     // To see the sample configuration of all possible objects please consult
     // ./sample-provisioning-info.js on the same folder
     provisioningInfo: {
+        'role': [
+            {
+                'name': 'User',
+                'description': 'A test role used for testing the install wizard!',
+                'permissions': ['premium_app_permission'],
+                'assignToSelf': true
+            }
+        ],
         'oauth-client': [
             {
                 'name': 'OAuth_Client',
                 'description': 'Generated Client that\'s passed to the App Backend',
-                'roles': ['User', 'Supervisor'],
+                'roles': ['User'],
                 'authorizedGrantType': 'CLIENT_CREDENTIALS',
-                /** NOTE: 
+                /** NOTE:
                  * If you want to learn how you can send the created credentials back to your system,
                  * Please read about the Post Custom Setup module here:
                  * https://developer.genesys.cloud/appfoundry/premium-app-wizard/7-custom-setup#post-custom-setup-module
@@ -92,13 +100,13 @@ export default {
         ],
         'audiohook': [
             {
-                'name': 'Audiohook_Install_Wizard_Test',
-                'autoEnable': true,
+                'name': 'Audiohook',
+                'autoEnable': false,
                 'channel': 'both',
-                'connectionUri': 'wss://PLACEHOLDER',
+                'connectionUri': '',
                 'credentials': {
-                    'apiKey': 'PLACEHOLDER',
-                    'clientSecret': 'placeholder'
+                    'apiKey': '',
+                    'clientSecret': ''
                 }
             }
         ]


### PR DESCRIPTION
This PR fixes some small bugs that caused the install wizard to need a manual refresh for success.

- Using an existing Role with the created OAuth client causes the install wizard to hang, so a new Role must be created instead
- Switched to using Genesys default Audiohook values instead of custom ones since these values will be invalid anyway